### PR TITLE
[arguments] Remove remote argument

### DIFF
--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -18,6 +18,11 @@ from tflens.helper.table import (
   MarkdownTableHelper,
   HtmlTableHelper
 )
+from tflens.helper.remote import RemoteHelper
+from tflens.helper.location import (
+  S3LocationHelper,
+  HttpLocationHelper
+)
 
 class TestTableHelper(unittest.TestCase):
 
@@ -108,3 +113,83 @@ class TestHtmlTableHelper(unittest.TestCase):
       html_file_content = html_file.read()
 
     self.assertEqual(html_file_content.replace('\n', ''), self.file_htmltable_output.replace('\n', ''))
+
+class TestRemoteHelper(unittest.TestCase):
+
+  def setUp(self):
+    self.local_file_location = 'local/terraform.tfstate'
+    self.s3_file_location = 's3://local/terraform.tfstate'
+    self.http_file_location = 'http://local/terraform.tfstate'
+    self.https_file_location = 'https://local/terraform.tfstate'
+
+  def test_invoke_local_remote_controller(self):
+    remote_helper = RemoteHelper(self.local_file_location)
+
+    self.assertEqual(
+      remote_helper.get_remote_type(),
+      "local"
+    )
+
+  def test_invoke_s3_remote_controller(self):
+    remote_helper = RemoteHelper(self.s3_file_location)
+
+    self.assertEqual(
+      remote_helper.get_remote_type(),
+      "s3"
+    )
+
+  def test_invoke_http_remote_controller(self):
+    remote_helper = RemoteHelper(self.http_file_location)
+
+    self.assertEqual(
+      remote_helper.get_remote_type(),
+      "http"
+    )
+
+  def test_invoke_https_remote_controller(self):
+    remote_helper = RemoteHelper(self.https_file_location)
+
+    self.assertEqual(
+      remote_helper.get_remote_type(),
+      "https"
+    )
+
+class TestLocationHelper(unittest.TestCase):
+
+  def setUp(self):
+    self.s3_file_location = 's3://local/terraform.tfstate'
+    self.non_valid_s3_file_location = 's3:/local/terraform.tfstate'
+    self.http_file_location = 'http://local/terraform.tfstate'
+    self.non_valid_http_file_location = 'http:/local/terraform.tfstate'
+    self.https_file_location = 'https://local/terraform.tfstate'
+    self.non_valid_https_file_location = 'https:/local/terraform.tfstate'
+
+  def test_valid_s3_remote_location(self):
+    location_helper = S3LocationHelper(self.s3_file_location)
+
+    self.assertTrue(location_helper.validate())
+
+  def test_non_valid_s3_remote_location(self):
+    location_helper = S3LocationHelper(self.non_valid_s3_file_location)
+
+    self.assertFalse(location_helper.validate())
+
+  def test_valid_http_remote_location(self):
+    location_helper = HttpLocationHelper(self.http_file_location)
+
+    self.assertTrue(location_helper.validate())
+
+  def test_non_valid_http_remote_location(self):
+    location_helper = HttpLocationHelper(self.non_valid_http_file_location)
+
+    self.assertFalse(location_helper.validate())
+
+  def test_valid_https_remote_location(self):
+    location_helper = HttpLocationHelper(self.https_file_location)
+
+    self.assertTrue(location_helper.validate())
+
+  def test_non_valid_https_remote_location(self):
+    location_helper = HttpLocationHelper(self.non_valid_https_file_location)
+
+    self.assertFalse(location_helper.validate())

--- a/tflens/exception/exception.py
+++ b/tflens/exception/exception.py
@@ -36,3 +36,13 @@ class ServerUnavailable(CustomException):
 
   def __init__(self):
     super().__init__("The server is unavailable")
+
+class NotValidS3Location(CustomException):
+
+  def __init__(self):
+    super().__init__("Invalid S3 location. Must be something like 's3://bucket_name/key'")
+
+class NotValidHttpLocation(CustomException):
+
+  def __init__(self):
+    super().__init__("Invalid Http location. Must be something like 'http(s)://http_server/'")

--- a/tflens/helper/location.py
+++ b/tflens/helper/location.py
@@ -1,0 +1,21 @@
+import re
+
+class LocationHelper():
+
+  def __init__(self, file_location: str, validation_pattern: str):
+    self.__file_location = file_location
+    self.__validation_pattern = validation_pattern
+    self.__compiled_pattern = re.compile(self.__validation_pattern)
+
+  def validate(self):
+    return self.__compiled_pattern.search(self.__file_location)
+
+class S3LocationHelper(LocationHelper):
+
+  def __init__(self, file_location: str):
+    super().__init__(file_location=file_location, validation_pattern="s3\:\/\/.+\/.+")
+
+class HttpLocationHelper(LocationHelper):
+
+  def __init__(self, file_location: str):
+    super().__init__(file_location=file_location, validation_pattern="http(s)?\:\/\/.+")

--- a/tflens/helper/remote.py
+++ b/tflens/helper/remote.py
@@ -1,0 +1,26 @@
+from tflens.controller.tfstate import (
+  RemoteS3TfStateController,
+  RemoteHttpTfStateController,
+  LocalTfStateController
+)
+
+class RemoteHelper():
+
+  def __init__(self, file_location: str):
+    self.__file_location = file_location
+    self.__remote_router = {
+      's3': RemoteS3TfStateController,
+      'http': RemoteHttpTfStateController,
+      'https': RemoteHttpTfStateController,
+      'local': LocalTfStateController
+    }
+    self.__remote_type = "local"
+
+    if ":" in self.__file_location:
+      self.__remote_type = self.__file_location.split(":")[0]
+
+  def get_remote_type(self):
+    return self.__remote_type
+
+  def invoke_remote_controller(self, **kwargs):
+    return self.__remote_router[self.__remote_type](**kwargs)


### PR DESCRIPTION
This is a breaking change that removes the need to use the `--remote` argument using the `file_location` schema in order to auto-detect which type of remote state (or local) is being used. So:
* Remove remote specific parameter
* Add remote helper
* Add location helper
* Add file location validations in services
* Update tests

Closes #41 